### PR TITLE
Use referenced message content when empty

### DIFF
--- a/src/utils/email.ts
+++ b/src/utils/email.ts
@@ -346,10 +346,13 @@ export async function sendMessageEmailUpdate({
 		<br />
 	`;
 
-	emailContent += xmlEscape(
-		message.content?.replace(new RegExp(`^<@!${getBotUser().id}>`), '') ??
-			'[Missing message content]'
-	);
+	let messageContent = message.content?.replace(new RegExp(`^<@!${getBotUser().id}>`), '');
+	// Fetch the message's reply if the message has just a ping and nothing else
+	if (!messageContent && message?.reference?.messageId) {
+		const reply = await message.channel.messages.fetch(message.reference.messageId);
+		messageContent = reply.content;
+	}
+	emailContent += xmlEscape(messageContent ?? '[Missing message content]');
 
 	if (message.attachments.size > 0) {
 		emailContent += `

--- a/src/utils/email.ts
+++ b/src/utils/email.ts
@@ -346,12 +346,22 @@ export async function sendMessageEmailUpdate({
 		<br />
 	`;
 
-	let messageContent = message.content?.replace(new RegExp(`^<@!${getBotUser().id}>`), '');
+	let messageContent = message.content?.replace(
+		new RegExp(`^<@!${getBotUser().id}>`),
+		''
+	);
+
 	// Fetch the message's reply if the message has just a ping and nothing else
-	if (!messageContent && message?.reference?.messageId) {
-		const reply = await message.channel.messages.fetch(message.reference.messageId);
+	if (
+		messageContent === undefined &&
+		message?.reference?.messageId !== undefined
+	) {
+		const reply = await message.channel.messages.fetch(
+			message.reference.messageId
+		);
 		messageContent = reply.content;
 	}
+
 	emailContent += xmlEscape(messageContent ?? '[Missing message content]');
 
 	if (message.attachments.size > 0) {

--- a/src/utils/email.ts
+++ b/src/utils/email.ts
@@ -1,24 +1,24 @@
 /* eslint-disable no-await-in-loop */
 
-import * as process from 'node:process';
 import { Buffer } from 'node:buffer';
-import * as nodemailer from 'nodemailer';
-import onetime from 'onetime';
-import type { gmail_v1 } from 'googleapis';
+import * as process from 'node:process';
 import type { Message } from '@google-cloud/pubsub';
 import { PubSub } from '@google-cloud/pubsub';
 import * as cheerio from 'cheerio';
-import { convert as convertHtmlToText } from 'html-to-text';
-import { MessageAttachment } from 'discord.js';
 import type {
-	PartialMessage as DiscordPartialMessage,
 	Message as DiscordMessage,
+	PartialMessage as DiscordPartialMessage,
 } from 'discord.js';
-import xmlEscape from 'xml-escape';
+import { MessageAttachment } from 'discord.js';
+import type { gmail_v1 } from 'googleapis';
+import { convert as convertHtmlToText } from 'html-to-text';
+import * as nodemailer from 'nodemailer';
+import onetime from 'onetime';
 import { outdent } from 'outdent';
+import xmlEscape from 'xml-escape';
+import { getBotUser, getDiscordBot } from '~/utils/discord.js';
 import { getGmailClient } from '~/utils/google.js';
 import { logDebug } from '~/utils/log.js';
-import { getBotUser, getDiscordBot } from '~/utils/discord.js';
 
 // Map from channel IDs to a message ID.
 // This map contains the channel ID that corresponds with a particular user so that the emails are sent in replies
@@ -346,23 +346,31 @@ export async function sendMessageEmailUpdate({
 		<br />
 	`;
 
-	let messageContent = message.content?.replace(
+	const messageContent = message.content?.replace(
 		new RegExp(`^<@!${getBotUser().id}>`),
 		''
 	);
 
-	// Fetch the message's reply if the message has just a ping and nothing else
-	if (
-		messageContent === undefined &&
-		message?.reference?.messageId !== undefined
-	) {
-		const reply = await message.channel.messages.fetch(
-			message.reference.messageId
-		);
-		messageContent = reply.content;
+	let replyMessage: DiscordMessage | undefined;
+	if (message.reference?.messageId !== undefined) {
+		try {
+			replyMessage = await message.channel.messages.fetch(
+				message.reference.messageId
+			);
+		} catch {
+			// reply not found
+		}
 	}
 
-	emailContent += xmlEscape(messageContent ?? '[Missing message content]');
+	if (replyMessage !== undefined) {
+		emailContent += outdent`
+			<strong>Replied to <u>${replyMessage.author.tag}</u> who said: </strong>
+			${replyMessage.content}
+			<br/>
+		`;
+	}
+
+	emailContent += xmlEscape(messageContent ?? '[empty message]');
 
 	if (message.attachments.size > 0) {
 		emailContent += `


### PR DESCRIPTION
Allows forwarding messages by other people with minimal effort (no need to duplicated the message text).

Example:

![image](https://user-images.githubusercontent.com/27315593/160887717-59f60d77-b4e8-42c1-b45c-a15adbb74aac.png)

This would send the reply's content instead of `[Missing message content]`.

I'm unsure how this would work with edits. Maybe the bot could have a temporary map from references -> replies and check if the edited message was referenced by another message. Open to other solutions as always.